### PR TITLE
Add audio transcription script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # 3000-Studios-v1.0
+
+This repository provides a lightweight utility for transcribing English speech
+from audio files. The `transcribe_boost.py` script applies optional amplification
+and noise reduction before performing speech-to-text using the Whisper model.
+
+## Requirements
+
+- Python 3.8+
+- `ffmpeg` installed and available on your system path
+- Python packages listed in `requirements.txt`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python transcribe_boost.py <input-audio> [--amplify DB] [--denoise]
+```
+
+- `--amplify DB` — increase the volume by the specified number of decibels.
+- `--denoise` — apply simple noise reduction prior to transcription.
+
+The script outputs the recognized English text to standard output.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pydub
+noisereduce
+soundfile
+numpy
+whisper

--- a/transcribe_boost.py
+++ b/transcribe_boost.py
@@ -1,0 +1,62 @@
+import argparse
+import os
+
+from pydub import AudioSegment
+import noisereduce as nr
+import numpy as np
+import soundfile as sf
+try:
+    import whisper
+except ImportError:
+    whisper = None
+
+
+def load_audio(path: str) -> AudioSegment:
+    """Load an audio file using pydub."""
+    return AudioSegment.from_file(path)
+
+
+def amplify(audio: AudioSegment, db: float) -> AudioSegment:
+    """Amplify audio by the specified decibels."""
+    return audio + db
+
+
+def reduce_noise(audio: AudioSegment) -> AudioSegment:
+    """Apply simple noise reduction using noisereduce."""
+    samples = np.array(audio.get_array_of_samples()).astype(np.float32)
+    reduced = nr.reduce_noise(y=samples, sr=audio.frame_rate)
+    # convert back to pydub AudioSegment
+    return audio._spawn(reduced.astype(np.int16).tobytes())
+
+
+def transcribe(audio: AudioSegment) -> str:
+    """Transcribe audio using whisper if available."""
+    temp_path = "_temp.wav"
+    audio.export(temp_path, format="wav")
+    if whisper is None:
+        raise ImportError("whisper library is required for transcription")
+    model = whisper.load_model("base")
+    result = model.transcribe(temp_path, language="en")
+    os.remove(temp_path)
+    return result.get("text", "")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe and clean English audio")
+    parser.add_argument("input", help="Path to input audio file")
+    parser.add_argument("--amplify", type=float, default=0.0, help="Amplify volume in dB")
+    parser.add_argument("--denoise", action="store_true", help="Apply noise reduction")
+    args = parser.parse_args()
+
+    audio = load_audio(args.input)
+    if args.amplify:
+        audio = amplify(audio, args.amplify)
+    if args.denoise:
+        audio = reduce_noise(audio)
+
+    text = transcribe(audio)
+    print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python script `transcribe_boost.py` for amplifying, denoising and transcribing audio
- document usage in README
- add `requirements.txt`

## Testing
- `python -m py_compile transcribe_boost.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684271942df483298c132c9125fbe65b